### PR TITLE
Adding friend_with method to the friendship model plus tests

### DIFF
--- a/lib/amistad/active_record/friendship_model.rb
+++ b/lib/amistad/active_record/friendship_model.rb
@@ -44,6 +44,14 @@ module Amistad
         def can_unblock?(user)
           blocked? && self.blocker == user
         end
+
+        def friend_with(user)
+          if user == self.user
+            return self.friend
+          elsif user == self.friend
+            return self.user
+          end
+        end
       end
     end
   end

--- a/spec/activerecord/activerecord_friendship_model_spec.rb
+++ b/spec/activerecord/activerecord_friendship_model_spec.rb
@@ -3,8 +3,28 @@ require File.dirname(__FILE__) + "/activerecord_spec_helper"
 describe Amistad::ActiveRecord::FriendshipModel do
 
   before(:all) do
-    %w(Jane David).each do |name|
+    %w(Jane David Bob).each do |name|
       instance_variable_set("@#{name.downcase}".to_sym, User.create(:name => name))
+    end
+  end
+
+  context "when finding one user from another" do
+    before do
+      Friendship.delete_all
+      @jane.invite(@david)
+      @friendship = Friendship.first
+    end
+
+    it "should find the invited friend given the inviting friend" do
+      @friendship.friend_with(@jane).should == @david
+    end
+
+    it "should find the inviting friend given the invited friend" do
+      @friendship.friend_with(@david).should == @jane
+    end
+
+    it "should return nil if the friendship does not include the user" do
+      @friendship.friend_with(@bob).should be_nil
     end
   end
 


### PR DESCRIPTION
I've been using this gem and finding it really easy to work with.  The only thing I've been wishing for is a way to find a user given a friendship and the other friend involved in the friendship.  

My particular use case is a Rails application that uses RESTful routes such as "/friendships/3" (where 3 is the ID of the friendship) - on the controller side, I know the friendship (from the id param), I know one user in the friendship (from the logged in current_user), but I don't know the other user, and I need to retrieve it so I can block/unblock/approve/whatever.

I've added a simple friend_with method to the friendship model that will, given one half of the friendship, return the other half.  Let me know if there's an easier/cleaner way to accomplish what I'm trying to do that I've overlooked.
