### PR TITLE
Fix for issue with attr_accessible

### DIFF
--- a/lib/amistad/active_record_friend_model.rb
+++ b/lib/amistad/active_record_friend_model.rb
@@ -130,14 +130,14 @@ module Amistad
     def invited_by?(user)
       friendship = find_any_friendship_with(user)
       return false if friendship.nil?
-      friendship.friendable == user
+      friendship.friendable_id == user.id
     end
 
     # checks if a current user invited given user
     def invited?(user)
       friendship = find_any_friendship_with(user)
       return false if friendship.nil?
-      friendship.friend == user
+      friendship.friend_id == user.id
     end
 
     # return the list of the ones among its friends which are also friend with the given use

--- a/lib/amistad/active_record_friendship_model.rb
+++ b/lib/amistad/active_record_friendship_model.rb
@@ -17,6 +17,8 @@ module Amistad
 
       validates_presence_of :friendable_id, :friend_id
       validates_uniqueness_of :friend_id, :scope => :friendable_id
+      
+      attr_accessible :friendable_id, :friend_id, :blocker_id, :pending
     end
 
     # returns true if a friendship has been approved, else false


### PR DESCRIPTION
I was not able to use invite method because of 
`ActiveModel::MassAssignmentSecurity::Error: Can't mass-assign protected attributes: friendable_id, friend_id`

I think it's because of changes in rails 3.2.3, which been done after github's fail with attr_accessible. 
