### PR TITLE
Mass-assignment problem fixed.

### DIFF
--- a/lib/amistad/active_record_friend_model.rb
+++ b/lib/amistad/active_record_friend_model.rb
@@ -58,7 +58,7 @@ module Amistad
     # suggest a user to become a friend. If the operation succeeds, the method returns true, else false
     def invite(user)
       return false if user == self || find_any_friendship_with(user)
-      Amistad.friendship_class.new(:friendable_id => self.id, :friend_id => user.id).save
+      Amistad.friendship_class.new{ |f| f.friendable = self ; f.friend = user }.save
     end
 
     # approve a friendship invitation. If the operation succeeds, the method returns true, else false

--- a/spec/activerecord/friend_spec.rb
+++ b/spec/activerecord/friend_spec.rb
@@ -4,6 +4,10 @@ describe "The friend model" do
   before(:all) do
     reload_environment
     User = Class.new(ActiveRecord::Base)
+
+    ActiveSupport.on_load(:active_record) do
+      attr_accessible(nil)
+    end
   end
 
   it_should_behave_like "friend with parameterized models" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,7 @@ Dir["#{File.dirname(__FILE__)}/support/*.rb"].each {|f| require f}
 def create_users(friend_model)
   friend_model.delete_all
   %w(John Jane David James Peter Mary Victoria Elisabeth).each do |name|
-    instance_variable_set("@#{name.downcase}".to_sym, friend_model.create(:name => name))
+    instance_variable_set("@#{name.downcase}".to_sym, friend_model.create{ |fm| fm.name = name})
   end
 end
 


### PR DESCRIPTION
Depending on ActiveRecord configuration, massive assignment might be disabled for models which do not specify explicit attr_accessible or attr_protected.

This pull request removes mass-assignments present in Friend#invite.  Also, it ensures that ActiveRecord mass-assignment is disabled by default in whole specs.
