### PR TITLE
Return relation instead of array

### DIFF
--- a/lib/amistad/mongo_friend_model.rb
+++ b/lib/amistad/mongo_friend_model.rb
@@ -10,7 +10,6 @@ module Amistad
 
       if self.save
         if user.save
-          log_user(logger, user)
           true
         else
           log_user(logger, user)
@@ -33,7 +32,6 @@ module Amistad
  #     self.save && user.save
       if self.save
         if user.save
-          log_user(logger, user)
           true
         else
           log_user(logger, user)

--- a/lib/amistad/mongo_friend_model.rb
+++ b/lib/amistad/mongo_friend_model.rb
@@ -20,7 +20,7 @@ module Amistad
 
     # returns the list of approved friends
     def friends
-      self.invited + self.invited_by
+      self.class.in(id: friend_ids + inverse_friend_ids)
     end
 
     # total # of invited and invited_by without association loading
@@ -30,22 +30,22 @@ module Amistad
 
     # return the list of invited friends
     def invited
-      self.class.find(friend_ids)
+      self.class.in(id: friend_ids)
     end
 
     # return the list of friends who invited
     def invited_by
-      self.class.find(inverse_friend_ids)
+      self.class.in(id: inverse_friend_ids)
     end
 
     # return the list of pending invited friends
     def pending_invited
-      self.class.find(pending_friend_ids)
+      self.class.in(id: pending_friend_ids)
     end
 
     # return the list of pending friends who invited
     def pending_invited_by
-      self.class.find(pending_inverse_friend_ids)
+      self.class.in(id: pending_inverse_friend_ids)
     end
 
     # return the list of the ones among its friends which are also friend with the given use
@@ -134,7 +134,7 @@ module Amistad
     # returns the list of blocked friends
     def blocked
       blocked_ids = blocked_friend_ids + blocked_inverse_friend_ids + blocked_pending_inverse_friend_ids
-      self.class.find(blocked_ids)
+      self.class.in(id: blocked_ids)
     end
 
     # total # of blockades and blockedes_by without association loading

--- a/lib/amistad/mongo_friend_model.rb
+++ b/lib/amistad/mongo_friend_model.rb
@@ -2,20 +2,53 @@ module Amistad
   module MongoFriendModel
     # suggest a user to become a friend. If the operation succeeds, the method returns true, else false
     def invite(user)
+      logger = Logger.new(Rails.root.join('log', 'amistad_invite.log'))
       return false if friendshiped_with?(user) or user == self or blocked?(user)
       pending_friend_ids << user.id
       user.pending_inverse_friend_ids << self.id
-      self.save && user.save
+#      self.save && user.save
+
+      if self.save
+        if user.save
+          log_user(logger, user)
+          true
+        else
+          log_user(logger, user)
+          false
+        end
+      else
+        log_user(logger, self)
+        false
+      end
     end
 
     # approve a friendship invitation. If the operation succeeds, the method returns true, else false
     def approve(user)
+      logger = Logger.new(Rails.root.join('log', 'amistad_approve.log'))
       return false unless pending_inverse_friend_ids.include?(user.id) && user.pending_friend_ids.include?(self.id)
       pending_inverse_friend_ids.delete(user.id)
       user.pending_friend_ids.delete(self.id)
       inverse_friend_ids << user.id
       user.friend_ids << self.id
-      self.save && user.save
+ #     self.save && user.save
+      if self.save
+        if user.save
+          log_user(logger, user)
+          true
+        else
+          log_user(logger, user)
+          false
+        end
+      else
+        log_user(logger, self)
+        false
+      end
+    end
+
+    def log_user(logger, user)
+      logger.info('*'*90)
+      logger.info(user.errors)
+      logger.info('*'*90)
     end
 
     # returns the list of approved friends

--- a/spec/support/friend_examples.rb
+++ b/spec/support/friend_examples.rb
@@ -59,14 +59,14 @@ shared_examples_for "a friend model" do
     end
 
     it "should list all the friends" do
-      @john.friends.should =~ [@mary, @james]
+      @john.friends.all.to_a.should =~ [@mary, @james]
     end
 
     it "should not list non-friended users" do
-      @victoria.friends.should be_empty
-      @john.friends.should =~ [@mary, @james]
-      @john.friends.should_not include(@peter)
-      @john.friends.should_not include(@victoria)
+      @victoria.friends.all.to_a.should be_empty
+      @john.friends.all.to_a.should =~ [@mary, @james]
+      @john.friends.all.to_a.should_not include(@peter)
+      @john.friends.all.to_a.should_not include(@victoria)
     end
 
     it "should list the friends who invited him" do
@@ -270,18 +270,18 @@ shared_examples_for "a friend model" do
     end
 
     it "should list the blocked users" do
-      @jane.blocked.should be_empty
-      @peter.blocked.should be_empty
-      @james.blocked.should == [@john]
-      @victoria.blocked.should == [@mary]
-      @david.blocked.should =~ [@john, @victoria]
+      @jane.blocked.all.to_a.should be_empty
+      @peter.blocked.all.to_a.should be_empty
+      @james.blocked.all.to_a.should == [@john]
+      @victoria.blocked.all.to_a.should == [@mary]
+      @david.blocked.all.to_a.should =~ [@john, @victoria]
     end
 
     it "should not list blocked users in friends" do
-      @james.friends.should =~ [@jane, @victoria]
+      @james.friends.all.to_a.should =~ [@jane, @victoria]
       @james.blocked.each do |user|
-        @james.friends.should_not include(user)
-        user.friends.should_not include(@james)
+        @james.friends.all.to_a.should_not include(user)
+        user.friends.all.to_a.should_not include(@james)
       end
     end
 
@@ -352,10 +352,10 @@ shared_examples_for "a friend model" do
     end
 
     it "should list unblocked users in friends" do
-      @john.friends.should == [@james]
-      @mary.friends.should == [@victoria]
-      @victoria.friends.should =~ [@mary, @james]
-      @james.friends.should =~ [@john, @jane, @victoria]
+      @john.friends.all.to_a.should == [@james]
+      @mary.friends.all.to_a.should == [@victoria]
+      @victoria.friends.all.to_a.should =~ [@mary, @james]
+      @james.friends.all.to_a.should =~ [@john, @jane, @victoria]
     end
 
     it "should list unblocked users in invited" do
@@ -364,12 +364,12 @@ shared_examples_for "a friend model" do
     end
 
     it "should list unblocked users in invited by" do
-      @victoria.invited_by.should == [@mary]
-      @james.invited_by.should =~ [@john, @jane, @victoria]
+      @victoria.invited_by.all.to_a.should == [@mary]
+      @james.invited_by.all.to_a.should =~ [@john, @jane, @victoria]
     end
 
     it "should list unblocked users in pending invited" do
-      @victoria.pending_invited.should =~ [@jane, @david]
+      @victoria.pending_invited.all.to_a.should =~ [@jane, @david]
     end
 
     it "should list unblocked users in pending invited by" do


### PR DESCRIPTION
When I try to use kaminari with amistad I realized that it returns arrays instead of relations. I thought it would be reasonable to return relations so additional scopes can be added.
