### PR TITLE
Remove squeel dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ pkg/*
 spec/db/*.db
 nbproject
 .rvmrc
+.ruby-version
+.ruby-gemset
+.idea
 *.sw[a-z]
 .rspec
 database.yml

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     amistad (0.10.0)
-      squeel
 
 GEM
   remote: http://rubygems.org/
@@ -57,8 +56,6 @@ GEM
     pg (0.17.1)
     plucky (0.3.8)
       mongo (~> 1.3)
-    polyamorous (1.1.0)
-      activerecord (>= 3.0)
     rake (10.3.2)
     rspec (3.1.0)
       rspec-core (~> 3.1.0)
@@ -74,10 +71,6 @@ GEM
     rspec-support (3.1.0)
     ruby-progressbar (1.6.0)
     sqlite3 (1.3.9)
-    squeel (1.2.1)
-      activerecord (>= 3.0)
-      activesupport (>= 3.0)
-      polyamorous (~> 1.1.0)
     thread_safe (0.3.4)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)

--- a/amistad.gemspec
+++ b/amistad.gemspec
@@ -14,8 +14,6 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "amistad"
 
-  s.add_dependency 'squeel'
-
   s.add_development_dependency "bundler"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", "~> 3.1.0"


### PR DESCRIPTION
Squeel is slowing down everything, adds unneeded dependency and can cause strange errors ( https://github.com/rails/rails/issues/16070 ). We could update squeel to newest version from master, but I think its better to remove it.
