### PR TITLE
Add add_friendship method

### DIFF
--- a/lib/amistad/active_record_friend_model.rb
+++ b/lib/amistad/active_record_friend_model.rb
@@ -49,6 +49,12 @@ module Amistad
       friendship.update_attribute(:pending, false)
     end
 
+    # adds a friendship directly, without invitation process
+    def add_friendship(user)
+      return false if user == self || find_any_friendship_with(user)
+      Amistad.friendship_class.new{ |f| f.friendable = self ; f.friend = user ; f.pending = false }.save
+    end
+
     # deletes a friendship
     def remove_friendship(user)
       friendship = find_any_friendship_with(user)

--- a/lib/amistad/mongo_friend_model.rb
+++ b/lib/amistad/mongo_friend_model.rb
@@ -74,6 +74,14 @@ module Amistad
       self.friend_ids.include?(user.id) or self.pending_friend_ids.include?(user.id)
     end
 
+    # adds a friendship directly, without invitation process
+    def add_friendship(user)
+      return false if friendshiped_with?(user) or user == self or blocked?(user)
+      inverse_friend_ids << user.id
+      user.friend_ids << self.id
+      self.save && user.save
+    end
+
     # deletes a friendship
     def remove_friendship(user)
       friend_ids.delete(user.id)


### PR DESCRIPTION
Sometimes you want to add friendship without invitation process, for example when programmatically adding friendships through external integration. This pull request adds method `add_friendship` that is basically `invite` + `approve` but in one step instead of two.
