### PR TITLE
Add support to namespaced friend model

### DIFF
--- a/lib/amistad/config.rb
+++ b/lib/amistad/config.rb
@@ -11,11 +11,11 @@ module Amistad
     end
 
     def friendship_model
-      "#{self.friend_model}Friendship"
+      "Friendship"
     end
 
     def friendship_class
-      Amistad::Friendships.const_get(self.friendship_model)
+      Amistad::Friendships::Friendship
     end
   end
 end


### PR DESCRIPTION
This commit only removes the unecessary dependency of friendship_model naming.

It's uneeded to have a friendship_model dependent on friend_model's name.

The purpose of this commit is to solve problems with namespaced models (e.g. 'User::Profile').
